### PR TITLE
fix(authentication): handle new case where type is none

### DIFF
--- a/src/RequestHook.js
+++ b/src/RequestHook.js
@@ -31,8 +31,7 @@ module.exports = async ({request, store, network}) => {
             token = await store.getItem(tokenKey),
             authRequestId = await store.getItem(buildStoreKey(STORE_REQUEST_ID_KEY, workspace)),
             hasAuthHeader = hasAuthentication(request)
-        // hasAuthHeader = request.hasHeader(HEADER_AUTHORIZATION) || Object.keys(request.getAuthentication()).length,
-        prefix = request.getEnvironmentVariable(ENVIRONMENT_PREFIX_KEY) ?? ENVIRONMENT_DEFAULT_PREFIX;
+            prefix = request.getEnvironmentVariable(ENVIRONMENT_PREFIX_KEY) ?? ENVIRONMENT_DEFAULT_PREFIX;
 
         if (authRequestId === null || (request.getId() === authRequestId) || hasAuthHeader) {
             return;

--- a/src/RequestHook.js
+++ b/src/RequestHook.js
@@ -9,6 +9,20 @@ const
     } = require('./constants'),
     {buildStoreKey, isTokenExpired, requestFromId} = require('./Utils');
 
+const hasAuthentication = (request) => {
+    if (request.hasHeader(HEADER_AUTHORIZATION)) {
+        return true;
+    }
+
+    // When no authentication method is selected in the UI, the request.getAuthentication() will return {type: 'none'}
+    const authentication = request.getAuthentication();
+    if (authentication.type === 'none') {
+        return false;
+    }
+
+    return Object.keys(authentication).length;
+}
+
 module.exports = async ({request, store, network}) => {
     try {
         const
@@ -16,8 +30,9 @@ module.exports = async ({request, store, network}) => {
             tokenKey = buildStoreKey(STORE_TOKEN_KEY, workspace, {_id: request.getEnvironment().getEnvironmentId()}),
             token = await store.getItem(tokenKey),
             authRequestId = await store.getItem(buildStoreKey(STORE_REQUEST_ID_KEY, workspace)),
-            hasAuthHeader = request.hasHeader(HEADER_AUTHORIZATION) || Object.keys(request.getAuthentication()).length,
-            prefix = request.getEnvironmentVariable(ENVIRONMENT_PREFIX_KEY) ?? ENVIRONMENT_DEFAULT_PREFIX;
+            hasAuthHeader = hasAuthentication(request)
+        // hasAuthHeader = request.hasHeader(HEADER_AUTHORIZATION) || Object.keys(request.getAuthentication()).length,
+        prefix = request.getEnvironmentVariable(ENVIRONMENT_PREFIX_KEY) ?? ENVIRONMENT_DEFAULT_PREFIX;
 
         if (authRequestId === null || (request.getId() === authRequestId) || hasAuthHeader) {
             return;


### PR DESCRIPTION
Fix. an error with latest Insomnia version.
When no authentication method is selected, the `request.getAuthentication()` method will return `{type: 'none'}` when has a `length` of `1` and will always fall in the "authenticated" case, which will not let us use the JWT token retrieved.